### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [Installation](#installation) •
 [Usage](#usage)
 
+[![smithery badge](https://smithery.ai/badge/mcp-summarization-functions)](https://smithery.ai/server/mcp-summarization-functions)
 [![npm version](https://badge.fury.io/js/mcp-summarization-functions.svg)](https://www.npmjs.com/package/mcp-summarization-functions)
 
 </div>
@@ -20,6 +21,14 @@
 A powerful MCP server that provides intelligent summarization capabilities through a clean, extensible architecture. Built with modern TypeScript and designed for seamless integration with AI workflows.
 
 ## Installation
+
+### Installing via Smithery
+
+To install Summarization Functions for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-summarization-functions):
+
+```bash
+npx -y @smithery/cli install mcp-summarization-functions --client claude
+```
 
 ```bash
 npm i mcp-summarization-functions


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Summarization Functions for Claude Desktop using Smithery CLI. This provides a streamlined approach for users to install the MCP easily.
2. Adds a badge displaying the number of installations from Smithery: https://smithery.ai/server/mcp-summarization-functions

Let me know if any tweaks have to be made!